### PR TITLE
update to terraform 12.5

### DIFF
--- a/ec2/main.tf
+++ b/ec2/main.tf
@@ -1,17 +1,17 @@
 resource "aws_key_pair" "upload_key" {
-  key_name              = "${var.key_name}"
-  public_key            = "${file("${var.ssh_path}/${var.key_name}.pub")}"
+  key_name   = var.key_name
+  public_key = file("${var.ssh_path}/${var.key_name}.pub")
 }
 
 resource "aws_instance" "teamcity" {
-  ami                         = "${var.ami}"
+  ami                         = var.ami
   instance_type               = "t3.medium"
-  key_name                    = "${var.key_name}"
-  subnet_id                   = "${var.public_subnet_id}"
-  user_data                   = "${data.template_file.teamcity_userdata.rendered}"
-  vpc_security_group_ids      = ["${var.vpc_security_group_ids}"]
+  key_name                    = var.key_name
+  subnet_id                   = var.public_subnet_id
+  user_data                   = data.template_file.teamcity_userdata.rendered
+  vpc_security_group_ids      = [var.vpc_security_group_ids]
   associate_public_ip_address = true
-  depends_on                  = ["aws_key_pair.upload_key"]
+  depends_on                  = [aws_key_pair.upload_key]
 
   tags = {
     Name = "TeamCity"
@@ -23,13 +23,14 @@ resource "aws_instance" "teamcity" {
 }
 
 data "template_file" "teamcity_userdata" {
-  template = "${file("${path.module}/scripts/db_setup.sh")}"
+  template = file("${path.module}/scripts/db_setup.sh")
 
-  vars {
-    db_url      = "${var.db_url}"
-    db_port     = "${var.db_port}"
-    db_name     = "${var.db_name}"
-    db_username = "${var.db_username}"
-    db_password = "${var.db_password}"
+  vars = {
+    db_url      = var.db_url
+    db_port     = var.db_port
+    db_name     = var.db_name
+    db_username = var.db_username
+    db_password = var.db_password
   }
 }
+

--- a/ec2/outputs.tf
+++ b/ec2/outputs.tf
@@ -1,3 +1,4 @@
 output "teamcity_web_ip" {
-  value = "${aws_instance.teamcity.public_dns}"
+  value = aws_instance.teamcity.public_dns
 }
+

--- a/ec2/variables.tf
+++ b/ec2/variables.tf
@@ -38,3 +38,4 @@ variable "ssh_path" {
 variable "vpc_security_group_ids" {
   default = "default value"
 }
+

--- a/ec2/versions.tf
+++ b/ec2/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,52 +1,89 @@
 provider "aws" {
-  access_key = "${var.aws_access_key}"
-  secret_key = "${var.aws_secret_key}"
-  region     = "${var.region}"
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+  region     = var.region
 }
 
-data "aws_availability_zones" "zones" {}
+data "aws_availability_zones" "zones" {
+}
 
 module "vpc" {
-  source             = "vpc"
-  availability_zones = ["${data.aws_availability_zones.zones.names}"]
+  # TF-UPGRADE-TODO: In Terraform v0.11 and earlier, it was possible to
+  # reference a relative module source without a preceding ./, but it is no
+  # longer supported in Terraform v0.12.
+  #
+  # If the below module source is indeed a relative local path, add ./ to the
+  # start of the source string. If that is not the case, then leave it as-is
+  # and remove this TODO comment.
+  source             = "./vpc"
+  availability_zones = data.aws_availability_zones.zones.names
   length             = 2
 }
 
 module "sg" {
-  source = "sg"
-  vpc_id = "${module.vpc.vpc_id}"
+  # TF-UPGRADE-TODO: In Terraform v0.11 and earlier, it was possible to
+  # reference a relative module source without a preceding ./, but it is no
+  # longer supported in Terraform v0.12.
+  #
+  # If the below module source is indeed a relative local path, add ./ to the
+  # start of the source string. If that is not the case, then leave it as-is
+  # and remove this TODO comment.
+  source = "./sg"
+  vpc_id = module.vpc.vpc_id
 }
 
 module "rds" {
-  source                 = "rds"
-  db_name                = "${var.db_name}"
-  db_password            = "${var.db_password}"
-  db_username            = "${var.db_username}"
-  db_subnet_group_name   = "${module.vpc.db_subnet_group_name}"
+  # TF-UPGRADE-TODO: In Terraform v0.11 and earlier, it was possible to
+  # reference a relative module source without a preceding ./, but it is no
+  # longer supported in Terraform v0.12.
+  #
+  # If the below module source is indeed a relative local path, add ./ to the
+  # start of the source string. If that is not the case, then leave it as-is
+  # and remove this TODO comment.
+  source                 = "./rds"
+  db_name                = var.db_name
+  db_password            = var.db_password
+  db_username            = var.db_username
+  db_subnet_group_name   = module.vpc.db_subnet_group_name
   dns_name               = "pg"
-  instance_identifier    = "${var.db_name}"
-  vpc_id                 = "${module.vpc.vpc_id}"
-  private_subnet_id      = ["${module.vpc.private_subnet}"]
+  instance_identifier    = var.db_name
+  vpc_id                 = module.vpc.vpc_id
+  private_subnet_id      = [module.vpc.private_subnet]
   service_name           = "TeamCity"
-  vpc_security_group_ids = "${module.sg.rds_security_groups_id}"
+  vpc_security_group_ids = module.sg.rds_security_groups_id
 }
 
 module "backup_bucket" {
-  source      = "s3"
-  name        = "${var.unique_s3_name}"
+  # TF-UPGRADE-TODO: In Terraform v0.11 and earlier, it was possible to
+  # reference a relative module source without a preceding ./, but it is no
+  # longer supported in Terraform v0.12.
+  #
+  # If the below module source is indeed a relative local path, add ./ to the
+  # start of the source string. If that is not the case, then leave it as-is
+  # and remove this TODO comment.
+  source      = "./s3"
+  name        = var.unique_s3_name
   description = "TeamCity Backups"
 }
 
 module "ec2" {
-  source                 = "ec2"
-  ami                    = "${var.debian_ami}"
-  db_username            = "${var.db_username}"
-  db_password            = "${var.db_password}"
-  db_name                = "${var.db_name}"
-  db_port                = "${module.rds.db_port}"
-  db_url                 = "${module.rds.database_address}"
-  key_name               = "${var.key_name}"
-  public_subnet_id       = "${module.vpc.public_subnet}"
-  ssh_path               = "${var.ssh_path}"
-  vpc_security_group_ids = "${module.sg.web_security_groups_id}"
+  # TF-UPGRADE-TODO: In Terraform v0.11 and earlier, it was possible to
+  # reference a relative module source without a preceding ./, but it is no
+  # longer supported in Terraform v0.12.
+  #
+  # If the below module source is indeed a relative local path, add ./ to the
+  # start of the source string. If that is not the case, then leave it as-is
+  # and remove this TODO comment.
+  source                 = "./ec2"
+  ami                    = var.debian_ami
+  db_username            = var.db_username
+  db_password            = var.db_password
+  db_name                = var.db_name
+  db_port                = module.rds.db_port
+  db_url                 = module.rds.database_address
+  key_name               = var.key_name
+  public_subnet_id       = module.vpc.public_subnet
+  ssh_path               = var.ssh_path
+  vpc_security_group_ids = module.sg.web_security_groups_id
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,7 @@
 output "teamcity_web_ssh_command" {
-  value = "${format("ssh -i ~/.ssh/teamcity admin@%s", "${module.ec2.teamcity_web_ip}")}"
+  value = format(
+    "ssh -i ~/.ssh/teamcity admin@%s",
+    module.ec2.teamcity_web_ip,
+  )
 }
+

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -1,24 +1,25 @@
 resource "aws_db_instance" "database" {
-  identifier                = "${var.instance_identifier}"
-  final_snapshot_identifier = "${var.instance_identifier}"
+  identifier                = var.instance_identifier
+  final_snapshot_identifier = var.instance_identifier
   skip_final_snapshot       = true
   allocated_storage         = "60"
   storage_type              = "gp2"
   engine                    = "postgres"
   instance_class            = "db.t2.medium"
-  name                      = "${var.db_name}"
-  username                  = "${var.db_username}"
-  password                  = "${var.db_password}"
+  name                      = var.db_name
+  username                  = var.db_username
+  password                  = var.db_password
   port                      = 5432
   publicly_accessible       = false
-  vpc_security_group_ids    = ["${var.vpc_security_group_ids}"]
-  db_subnet_group_name      = "${var.db_subnet_group_name}"
+  vpc_security_group_ids    = [var.vpc_security_group_ids]
+  db_subnet_group_name      = var.db_subnet_group_name
   multi_az                  = true
   backup_retention_period   = 7
   backup_window             = "08:17-08:47"
   maintenance_window        = "sat:09:30-sat:22:00"
 
-  tags {
+  tags = {
     Name = "TeamCity RDS"
   }
 }
+

--- a/rds/outputs.tf
+++ b/rds/outputs.tf
@@ -1,7 +1,8 @@
 output "database_address" {
-  value = "${replace(aws_db_instance.database.endpoint, ":5432", "")}"
+  value = replace(aws_db_instance.database.endpoint, ":5432", "")
 }
 
 output "db_port" {
   value = "5432"
 }
+

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -37,3 +37,4 @@ variable "vpc_id" {
 variable "vpc_security_group_ids" {
   default = "default value"
 }
+

--- a/rds/versions.tf
+++ b/rds/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/s3/main.tf
+++ b/s3/main.tf
@@ -1,8 +1,9 @@
 resource "aws_s3_bucket" "backup_bucket" {
-  bucket = "${var.name}"
+  bucket = var.name
   acl    = "private"
 
-  tags {
-    Name = "${var.description}"
+  tags = {
+    Name = var.description
   }
 }
+

--- a/s3/outputs.tf
+++ b/s3/outputs.tf
@@ -1,3 +1,4 @@
 output "arn" {
-  value = "${aws_s3_bucket.backup_bucket.arn}"
+  value = aws_s3_bucket.backup_bucket.arn
 }
+

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -5,3 +5,4 @@ variable "name" {
 variable "description" {
   description = "Description of the S3 Bucket (for tagging)"
 }
+

--- a/s3/versions.tf
+++ b/s3/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/sg/main.tf
+++ b/sg/main.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "teamcity_web_sg" {
   name        = "TeamCity_sg"
   description = "Allow TeamCity SSH & HTTP inbound connection"
-  vpc_id      = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 
   ingress {
     from_port   = 22
@@ -24,7 +24,7 @@ resource "aws_security_group" "teamcity_web_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TeamCity Web Security Group"
   }
 }
@@ -32,7 +32,7 @@ resource "aws_security_group" "teamcity_web_sg" {
 resource "aws_security_group" "rds_sg" {
   name        = "TeamCity_rds_sg"
   description = "TeamCity RDS Security Group"
-  vpc_id      = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 
   # TODO: Should this change to only allow ssh from other IPs?
   ingress {
@@ -56,7 +56,8 @@ resource "aws_security_group" "rds_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TeamCity RDS Security Group"
   }
 }
+

--- a/sg/outputs.tf
+++ b/sg/outputs.tf
@@ -1,7 +1,8 @@
 output "web_security_groups_id" {
-  value = "${aws_security_group.teamcity_web_sg.id}"
+  value = aws_security_group.teamcity_web_sg.id
 }
 
 output "rds_security_groups_id" {
-  value = "${aws_security_group.rds_sg.id}"
+  value = aws_security_group.rds_sg.id
 }
+

--- a/sg/variables.tf
+++ b/sg/variables.tf
@@ -1,4 +1,5 @@
 variable "vpc_id" {
-  type        = "string"
+  type        = string
   description = "VPC ID in which to deploy RDS"
 }
+

--- a/sg/versions.tf
+++ b/sg/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "db_name" {
 }
 
 variable "db_password" {
-  type = "string"
+  type = string
 }
 
 variable "db_username" {
@@ -34,7 +34,7 @@ variable "ssh_path" {
   default = "~/.ssh"
 }
 
-
 variable "unique_s3_name" {
-  type = "string"
+  type = string
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -2,7 +2,8 @@ resource "aws_vpc" "vpc" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "TeamCity VPC"
   }
 }
+

--- a/vpc/nat.tf
+++ b/vpc/nat.tf
@@ -1,16 +1,17 @@
 resource "aws_eip" "nat_gw_eip" {
   vpc = true
 
-  tags {
+  tags = {
     Name = "TeamCity NAT"
   }
 }
 
 resource "aws_nat_gateway" "gw" {
-  allocation_id = "${aws_eip.nat_gw_eip.id}"
-  subnet_id     = "${aws_subnet.public.id}"
+  allocation_id = aws_eip.nat_gw_eip.id
+  subnet_id     = aws_subnet.public[0].id
 
-  tags {
+  tags = {
     Name = "TeamCity NAT Gateway"
   }
 }
+

--- a/vpc/outputs.tf
+++ b/vpc/outputs.tf
@@ -1,15 +1,16 @@
 output "db_subnet_group_name" {
-  value = "${aws_db_subnet_group.rds.name}"
+  value = aws_db_subnet_group.rds.name
 }
 
 output "private_subnet" {
-  value = ["${aws_subnet.private.*.id}"]
+  value = [aws_subnet.private.*.id]
 }
 
 output "public_subnet" {
-  value = "${aws_subnet.public.id}"
+  value = aws_subnet.public[0].id
 }
 
 output "vpc_id" {
-  value = "${aws_vpc.vpc.id}"
+  value = aws_vpc.vpc.id
 }
+

--- a/vpc/routing.tf
+++ b/vpc/routing.tf
@@ -1,44 +1,45 @@
 resource "aws_internet_gateway" "vpc_igw" {
-  vpc_id = "${aws_vpc.vpc.id}"
+  vpc_id = aws_vpc.vpc.id
 
-  tags {
+  tags = {
     Name = "TeamCity Gateway"
   }
 }
 
 resource "aws_route_table" "vpc_public" {
-  vpc_id = "${aws_vpc.vpc.id}"
+  vpc_id = aws_vpc.vpc.id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.vpc_igw.id}"
+    gateway_id = aws_internet_gateway.vpc_igw.id
   }
 
-  tags {
+  tags = {
     Name = "TeamCity Public Subnet Route Table"
   }
 }
 
 resource "aws_route_table_association" "vpc_public" {
-  subnet_id      = "${aws_subnet.public.id}"
-  route_table_id = "${aws_route_table.vpc_public.id}"
+  subnet_id      = aws_subnet.public[0].id
+  route_table_id = aws_route_table.vpc_public.id
 }
 
 resource "aws_route_table" "vpc_private" {
-  vpc_id = "${aws_vpc.vpc.id}"
+  vpc_id = aws_vpc.vpc.id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_nat_gateway.gw.id}"
+    gateway_id = aws_nat_gateway.gw.id
   }
 
-  tags {
+  tags = {
     Name = "TeamCity Private Subnet's Route Table"
   }
 }
 
 resource "aws_route_table_association" "vpc_private" {
-  count          = "${var.length}"
-  subnet_id      = "${element(aws_subnet.private.*.id, count.index)}"
-  route_table_id = "${aws_route_table.vpc_private.id}"
+  count          = var.length
+  subnet_id      = element(aws_subnet.private.*.id, count.index)
+  route_table_id = aws_route_table.vpc_private.id
 }
+

--- a/vpc/subnets.tf
+++ b/vpc/subnets.tf
@@ -1,30 +1,32 @@
 resource "aws_subnet" "private" {
-  availability_zone = "${element(var.availability_zones, count.index)}"
-  cidr_block        = "${element(var.private_cidr_block, count.index)}"
-  count             = "${length(var.private_cidr_block)}"
-  vpc_id            = "${aws_vpc.vpc.id}"
+  availability_zone = element(var.availability_zones, count.index)
+  cidr_block        = element(var.private_cidr_block, count.index)
+  count             = length(var.private_cidr_block)
+  vpc_id            = aws_vpc.vpc.id
 
-  tags {
-    Name = "${format("TeamCity Private Subnet %d", count.index + 1)}"
+  tags = {
+    Name = format("TeamCity Private Subnet %d", count.index + 1)
   }
 }
 
 resource "aws_db_subnet_group" "rds" {
   name        = "teamcity-subnet-group"
   description = "TeamCity RDS Subnet Group"
-  subnet_ids  = ["${aws_subnet.private.*.id}"]
+  subnet_ids  = aws_subnet.private.*.id
 
-  tags {
+  tags = {
     Name = "TeamCity RDS Subnet Group"
   }
 }
 
 resource "aws_subnet" "public" {
-  availability_zone = "${element(var.availability_zones, count.index)}"
-  cidr_block        = "${var.public_cidr_block}"
-  vpc_id            = "${aws_vpc.vpc.id}"
+  count             = length(var.private_cidr_block)
+  availability_zone = element(var.availability_zones, count.index)
+  cidr_block        = var.public_cidr_block
+  vpc_id            = aws_vpc.vpc.id
 
-  tags {
+  tags = {
     Name = "Public TeamCity Subnet"
   }
 }
+

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -1,6 +1,6 @@
 variable "availability_zones" {
   description = "List of availability zones over which to distribute subnets"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "length" {
@@ -12,6 +12,7 @@ variable "public_cidr_block" {
 }
 
 variable "private_cidr_block" {
-  type    = "list"
+  type    = list(string)
   default = ["10.0.1.0/24", "10.0.2.0/24"]
 }
+

--- a/vpc/versions.tf
+++ b/vpc/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Figured I'd save you the time if you're heading in this direction.

This update has only been planned, not actually run, so it may not entirely work yet.

I intend to modify this so the VPC is optional, since if I use it I'll be inside a company and already have allt he VPC resources, etc. set up.

I'm not sure if I'll be able to wrap enough resources to make that optional with this module or whether I"ll just need to basically re-write. Let me know if you have interest in the former.